### PR TITLE
Updated SubscriptionFormDialog to be more flexible

### DIFF
--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -14,7 +14,7 @@ import { connect } from "react-redux";
 import routes from "../routes";
 import AccountFormDialog from "../workspace/account/AccountFormDialog";
 import EditAccount from "../workspace/account/EditAccount";
-import NewSubscription from "../workspace/subscription/NewSubscription";
+import SubscriptionFormDialog from "../workspace/subscription/SubscriptionFormDialog";
 import NewTransaction from "../workspace/transaction/NewTransaction";
 import * as actions from "../redux/actions";
 
@@ -59,6 +59,7 @@ function MainLayout(props) {
         notification,
         closeNotification,
         createAccount,
+        createSubscription,
     } = props;
     const [drawerOpen, setDrawerOpen] = React.useState(false);
     const classes = useStyles();
@@ -137,7 +138,12 @@ function MainLayout(props) {
             {openDialog === "NEW_ACCOUNT" && (
                 <AccountFormDialog title="New Account" onSave={createAccount} />
             )}
-            {openDialog === "NEW_SUBSCRIPTION" && <NewSubscription />}
+            {openDialog === "NEW_SUBSCRIPTION" && (
+                <SubscriptionFormDialog
+                    title="New Subscription"
+                    onSave={createSubscription}
+                />
+            )}
             {openDialog === "NEW_TRANSACTION" && <NewTransaction />}
 
             {openDialog === "EDIT_ACCOUNT" && <EditAccount />}
@@ -157,6 +163,7 @@ function mapStateToProps(state) {
 const mapDispatchToProps = {
     closeNotification: actions.closeNotification,
     createAccount: actions.createAccount,
+    createSubscription: actions.createSubscription,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MainLayout);

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -220,7 +220,7 @@ mock.onPut(PUT_ACCOUNT_URL).reply((request) => {
 mock.onPost("/api/v1/subscriptions").reply((request) => {
     const subscription = JSON.parse(request.data);
     subscription.id = faker.random.uuid();
-    subscription.push(subscription);
+    subscriptions.push(subscription);
 
     return [200, subscription];
 });

--- a/src/workspace/RecordForm.js
+++ b/src/workspace/RecordForm.js
@@ -25,6 +25,16 @@ const useStyles = makeStyles((theme) => ({
 // multiple_options (multiselect), single_option (drop down)
 // lookup - organization, user, contact
 
+export function extractValues(groups) {
+    const result = {};
+    groups.forEach((group) => {
+        group.children.forEach(
+            (field) => (result[field.identifier] = field.defaultValue)
+        );
+    });
+    return result;
+}
+
 export default function RecordForm(props) {
     const { values, groups, showMore, onValueChange } = props;
     const classes = useStyles(props);

--- a/src/workspace/account/AccountFormDialog.js
+++ b/src/workspace/account/AccountFormDialog.js
@@ -6,9 +6,10 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Icon from "@material-ui/core/Icon";
 import { makeStyles } from "@material-ui/styles";
-import RecordForm from "../RecordForm";
 import PropTypes from "prop-types";
 
+import RecordForm from "../RecordForm";
+import { extractValues } from "../RecordForm";
 import * as actions from "../../redux/actions";
 import { connect } from "react-redux";
 
@@ -204,7 +205,7 @@ const groups = [
         ],
     },
     {
-        label: "Organization",
+        label: "Company",
         children: [
             {
                 label: "Name",
@@ -263,27 +264,12 @@ const groups = [
     },
 ];
 
-function extractValues(groups) {
-    const result = {};
-    groups.forEach((group) => {
-        group.children.forEach(
-            (field) => (result[field.identifier] = field.defaultValue)
-        );
-    });
-    return result;
-}
-
-// TODO: Use a deep cloning library!
-function copyObject(object) {
-    return JSON.parse(JSON.stringify(object));
-}
-
 function AccountFormDialog(props) {
     const { closeDialog, title, onSave } = props;
     const classes = useStyles(props);
     const [showMore, setShowMore] = React.useState(props.showMore);
     const [values, setValues] = React.useState(
-        props.account ? copyObject(props.account) : extractValues(groups)
+        props.account || extractValues(groups)
     );
     const handleShowMore = () => {
         setShowMore(!showMore);

--- a/src/workspace/account/EditAccount.js
+++ b/src/workspace/account/EditAccount.js
@@ -5,7 +5,7 @@ import * as actions from "../../redux/actions";
 import AccountFormDialog from "./AccountFormDialog";
 
 function EditAccount(props) {
-    const { account, saveAccount, clearAccount } = props;
+    const { account, saveAccount } = props;
     return (
         <AccountFormDialog
             title="Edit Account"

--- a/src/workspace/subscription/SubscriptionFormDialog.js
+++ b/src/workspace/subscription/SubscriptionFormDialog.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -6,9 +7,11 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Icon from "@material-ui/core/Icon";
 import { makeStyles } from "@material-ui/styles";
-import RecordForm from "../RecordForm";
-import * as actions from "../../redux/actions";
 import { connect } from "react-redux";
+
+import RecordForm from "../RecordForm";
+import { extractValues } from "../RecordForm";
+import * as actions from "../../redux/actions";
 
 const useStyles = makeStyles((theme) => ({
     extraAction: {
@@ -48,7 +51,7 @@ const groups = [
             {
                 label: "Plan",
                 identifier: "plan",
-                type: "text_field",
+                type: "text",
                 required: true,
                 readOnly: false,
                 quickAdd: true,
@@ -61,7 +64,7 @@ const groups = [
             {
                 label: "Billing Period",
                 identifier: "billingPeriod",
-                type: "text_field",
+                type: "text",
                 required: true,
                 readOnly: false,
                 quickAdd: true,
@@ -74,7 +77,7 @@ const groups = [
             {
                 label: "Billing Period Unit",
                 identifier: "billingPeriodUnit",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
                 quickAdd: true,
@@ -87,7 +90,7 @@ const groups = [
             {
                 label: "Setup Fee",
                 identifier: "setupFee",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
                 quickAdd: true,
@@ -100,10 +103,10 @@ const groups = [
             {
                 label: "Trial Period",
                 identifier: "trailPeriod",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
-                quickAdd: false,
+                quickAdd: true,
                 unique: false,
                 hidden: false,
                 tooltip: "The period of the trail subscription.",
@@ -113,10 +116,10 @@ const groups = [
             {
                 label: "Trial Period Unit",
                 identifier: "trialPeriodUnit",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
-                quickAdd: false,
+                quickAdd: true,
                 unique: false,
                 hidden: false,
                 tooltip: "Number of units of trial period.",
@@ -126,10 +129,10 @@ const groups = [
             {
                 label: "Starts",
                 identifier: "starts",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
-                quickAdd: false,
+                quickAdd: true,
                 unique: false,
                 hidden: false,
                 tooltip: "Start date of the subscription.",
@@ -139,10 +142,10 @@ const groups = [
             {
                 label: "Term",
                 identifier: "term",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
-                quickAdd: false,
+                quickAdd: true,
                 unique: false,
                 hidden: false,
                 tooltip: "Term of the subscription.",
@@ -152,10 +155,10 @@ const groups = [
             {
                 label: "Term Unit",
                 identifier: "termUnit",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
-                quickAdd: false,
+                quickAdd: true,
                 unique: false,
                 hidden: false,
                 tooltip: "Unit of the term.",
@@ -165,146 +168,10 @@ const groups = [
             {
                 label: "Renew",
                 identifier: "renew",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip:
-                    "Boolean value stating whether subscription is recurring.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-        ],
-    },
-    {
-        label: "Organization",
-        children: [
-            {
-                label: "Plan",
-                identifier: "plan",
-                type: "text_field",
-                required: true,
-                readOnly: false,
-                quickAdd: true,
-                unique: false,
-                hidden: false,
-                tooltip: "The plan associated with the subscription.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Billing Period",
-                identifier: "billingPeriod",
-                type: "text_field",
-                required: true,
-                readOnly: false,
-                quickAdd: true,
-                unique: false,
-                hidden: false,
-                tooltip: "The billing period of the subscription.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Billing Period Unit",
-                identifier: "billingPeriodUnit",
-                type: "text_field",
+                type: "text",
                 required: false,
                 readOnly: false,
                 quickAdd: true,
-                unique: false,
-                hidden: false,
-                tooltip: "The number of billing period units.",
-                multipleValues: true,
-                defaultValue: "",
-            },
-            {
-                label: "Setup Fee",
-                identifier: "setupFee",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: true,
-                unique: false,
-                hidden: false,
-                tooltip: "The fee required for setup of the subscription.",
-                multipleValues: true,
-                defaultValue: "",
-            },
-            {
-                label: "Trial Period",
-                identifier: "trailPeriod",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip: "The period of the trail subscription.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Trial Period Unit",
-                identifier: "trialPeriodUnit",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip: "Number of units of trial period.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Starts",
-                identifier: "starts",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip: "Start date of the subscription.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Term",
-                identifier: "term",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip: "Term of the subscription.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Term Unit",
-                identifier: "termUnit",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
-                unique: false,
-                hidden: false,
-                tooltip: "Unit of the term.",
-                multipleValues: false,
-                defaultValue: "",
-            },
-            {
-                label: "Renew",
-                identifier: "renew",
-                type: "text_field",
-                required: false,
-                readOnly: false,
-                quickAdd: false,
                 unique: false,
                 hidden: false,
                 tooltip:
@@ -316,42 +183,24 @@ const groups = [
     },
 ];
 
-function extractValues(groups) {
-    const result = [];
-    groups.forEach((group) => {
-        const values = group.children.map((field) => ({
-            identifier: field.identifier,
-            value: field.defaultValue,
-        }));
-        result.push(values);
-    });
-    return result;
-}
-
-function extractRecord(groups) {
-    const result = {};
-    groups.forEach((group) =>
-        group.forEach((field) => (result[field.identifier] = field.value))
-    );
-    return result;
-}
-
-function NewSubscription(props) {
-    const { closeDialog, createSubscription } = props;
+function SubscriptionFormDialog(props) {
+    const { title, closeDialog, onSave } = props;
     const classes = useStyles(props);
-    const [showMore, setShowMore] = React.useState(false);
-    const [values, setValues] = React.useState(extractValues(groups));
+    const [showMore, setShowMore] = React.useState(props.showMore);
+    const [values, setValues] = React.useState(
+        props.subscription || extractValues(groups)
+    );
     const handleShowMore = () => {
         setShowMore(!showMore);
     };
     const handleSave = () => {
         closeDialog();
-        createSubscription(extractRecord(values));
+        onSave(values);
     };
     // TODO: Create a deep copy without serializing !
-    const handleValueChange = (group, field, value) => {
+    const handleValueChange = (field, value) => {
         const newValues = JSON.parse(JSON.stringify(values));
-        newValues[group][field].value = value;
+        newValues[field.identifier] = value;
 
         setValues(newValues);
     };
@@ -359,11 +208,9 @@ function NewSubscription(props) {
     return (
         <Dialog
             open={true}
-            onClose={closeDialog}
-            aria-labelledby="form-dialog-title"
             className={showMore ? classes.mainMore : classes.mainLess}
         >
-            <DialogTitle id="form-dialog-title">New Subscription</DialogTitle>
+            <DialogTitle>{title}</DialogTitle>
             <DialogContent>
                 <RecordForm
                     showMore={showMore}
@@ -403,23 +250,37 @@ function NewSubscription(props) {
                         className={classes.dialogAction}
                     >
                         Save
-                </Button>
+                    </Button>
                     <Button
                         onClick={closeDialog}
                         color="primary"
                         className={classes.dialogAction}
                     >
                         Cancel
-                </Button>
+                    </Button>
                 </div>
             </DialogActions>
         </Dialog>
     );
 }
 
+SubscriptionFormDialog.propTypes = {
+    title: PropTypes.string.isRequired,
+    showMore: PropTypes.bool,
+    subscription: PropTypes.object,
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func,
+};
+
+SubscriptionFormDialog.defaultProps = {
+    showMore: false,
+    onCancel: false,
+    subscription: null,
+};
+
 const mapDispatchToProps = {
     closeDialog: actions.closeDialog,
     createSubscription: actions.createSubscription,
 };
 
-export default connect(null, mapDispatchToProps)(NewSubscription);
+export default connect(null, mapDispatchToProps)(SubscriptionFormDialog);


### PR DESCRIPTION
Since the `NewSubscription` component could be reused for editing subscriptions, it was renamed to
`SubscriptionFormDialog`.

The internal state of this component was significantly modified in this commit. Previously a two
dimensional array was used to keep track of all the values. Now we use key-value pairs. This change
was made to keep up with the `RecordForm`. However, the shape of the form state is somewhat
transparent because we use `extractValues` exported by the `RecordForm.js` module, which takes
care of extracting the default state based on the form configuration.