### PR TITLE
Added the date_range field type to RecordForm

### DIFF
--- a/src/workspace/RecordForm.js
+++ b/src/workspace/RecordForm.js
@@ -1,15 +1,20 @@
 import React from "react";
 import TextField from "@material-ui/core/TextField";
 import Grid from "@material-ui/core/Grid";
-import { makeStyles } from "@material-ui/styles";
 import DateFnsUtils from "@date-io/date-fns";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import FormGroup from "@material-ui/core/FormGroup";
+import Switch from "@material-ui/core/Switch";
+import FormControl from "@material-ui/core/FormControl";
+import InputLabel from "@material-ui/core/InputLabel";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import { makeStyles } from "@material-ui/styles";
+import { format } from "date-fns";
 import {
     MuiPickersUtilsProvider,
     KeyboardDatePicker,
 } from "@material-ui/pickers";
-import FormControlLabel from "@material-ui/core/FormControlLabel";
-import FormGroup from "@material-ui/core/FormGroup";
-import Switch from "@material-ui/core/Switch";
 
 const useStyles = makeStyles((theme) => ({
     root: {
@@ -38,7 +43,18 @@ export function extractValues(groups) {
     const result = {};
     groups.forEach((group) => {
         group.children.forEach(
-            (field) => (result[field.identifier] = field.defaultValue)
+            (field) => {
+                if (field.type === "date_range") {
+                    result[field.identifier] = {
+                        option: field.defaultValue.option,
+                        startDate: field.defaultValue.startDate,
+                        endDate: field.defaultValue.endDate,
+                    };
+                }
+                else {
+                    result[field.identifier] = field.defaultValue;
+                }
+            }
         );
     });
     return result;
@@ -50,6 +66,19 @@ export default function RecordForm(props) {
 
     const makeChangeHandler = (field) => (event) => {
         onValueChange(field, event.target.value);
+    };
+
+    const makeRangeHandler = (field) => (event) => {
+        const newValue = Object.assign({}, values[field.identifier]);
+        newValue.option = event.target.value;
+        onValueChange(field, newValue);
+    };
+
+    const makeDateChangeHandler = (field, which) => (date) => {
+        const newValue = Object.assign({}, values[field.identifier]);
+        // ISO format
+        newValue[which] = format(date, "yyyy/MM/dd");
+        onValueChange(field, newValue);
     };
 
     return (
@@ -112,12 +141,25 @@ export default function RecordForm(props) {
 
                                 {field.type === "date" && (
                                     <KeyboardDatePicker
-                                        margin="normal"
                                         id={field.identifier}
                                         label={field.label}
+                                        name={field.identifier}
                                         format="MM/dd/yyyy"
-                                        inputVariant="outlined"
                                         fullWidth={true}
+                                        inputVariant="outlined"
+                                        required={field.required}
+                                        value={
+                                            !values[field.identifier]
+                                                ? new Date()
+                                                : new Date(
+                                                      values[field.identifier]
+                                                  )
+                                        }
+                                        margin="normal"
+                                        onChange={makeDateChangeHandler(
+                                            field,
+                                            "startDate"
+                                        )}
                                         size="small"
                                     />
                                 )}
@@ -133,7 +175,93 @@ export default function RecordForm(props) {
                                             value={values[field.identifier]}
                                             onChange={makeChangeHandler(field)}
                                         />
-                                    </FormGroup>
+                                    </FormGroup>)}
+
+                                {field.type === "date_range" && (
+                                    <div>
+                                        <FormControl
+                                            variant="outlined"
+                                            fullWidth={true}
+                                            size="small"
+                                        >
+                                            <InputLabel id={field.identifier}>
+                                                {field.title}
+                                            </InputLabel>
+                                            <Select
+                                                labelId={field.identifier}
+                                                value={
+                                                    values[field.identifier]
+                                                        .option
+                                                }
+                                                onChange={makeRangeHandler(
+                                                    field
+                                                )}
+                                                label={field.title}
+                                            >
+                                                {field.options.map((option) => (
+                                                    <MenuItem
+                                                        value={option.value}
+                                                    >
+                                                        {option.title}
+                                                    </MenuItem>
+                                                ))}
+                                            </Select>
+                                        </FormControl>
+                                        {values[field.identifier].option ===
+                                            "custom" && (
+                                            <React.Fragment>
+                                                <KeyboardDatePicker
+                                                    margin="normal"
+                                                    id={
+                                                        field.identifier +
+                                                        "Start"
+                                                    }
+                                                    label={field.startTitle}
+                                                    format="MM/dd/yyyy"
+                                                    inputVariant="outlined"
+                                                    fullWidth={true}
+                                                    size="small"
+                                                    value={
+                                                        !values[field.identifier].startDate
+                                                            ? new Date()
+                                                            : new Date(
+                                                                  values[
+                                                                      field.identifier
+                                                                  ].startDate
+                                                              )
+                                                    }
+                                                    onChange={makeDateChangeHandler(
+                                                        field,
+                                                        "startDate"
+                                                    )}
+                                                />
+                                                <KeyboardDatePicker
+                                                    margin="normal"
+                                                    id={
+                                                        field.identifier + "End"
+                                                    }
+                                                    label={field.endTitle}
+                                                    format="MM/dd/yyyy"
+                                                    inputVariant="outlined"
+                                                    fullWidth={true}
+                                                    size="small"
+                                                    value={
+                                                        !values[field.identifier].endDate
+                                                            ? new Date()
+                                                            : new Date(
+                                                                  values[
+                                                                      field.identifier
+                                                                  ].endDate
+                                                              )
+                                                    }
+                                                    onChange={makeDateChangeHandler(
+                                                        field,
+                                                        "endDate"
+                                                    )}
+                                                />
+                                            </React.Fragment>
+                                        )}
+                                    </div>
                                 )}
                             </Grid>
                         ) : null

--- a/src/workspace/subscription/SubscriptionFormDrawer.js
+++ b/src/workspace/subscription/SubscriptionFormDrawer.js
@@ -9,6 +9,53 @@ const groups = [
     {
         label: "Basic",
         children: [
+            /*{
+                identifier: "date_range",
+                type: "date_range",
+                title: "Time Range",
+                startTitle: "Start Date",
+                endTitle: "End Date",
+                options: [
+                    {
+                        value: "all_time",
+                        title: "All Time",
+                    },
+                    {
+                        value: "last_3_months",
+                        title: "Last 3 Months",
+                    },
+                    {
+                        value: "last_6_months",
+                        title: "Last 6 Months",
+                    },
+                    {
+                        value: "last_9_months",
+                        title: "Last 9 Months",
+                    },
+                    {
+                        value: "last_12_months",
+                        title: "Last 12 Months",
+                    },
+                    {
+                        value: "last_15_months",
+                        title: "Last 15 Months",
+                    },
+                    {
+                        value: "last_18_months",
+                        title: "Last 18 Months",
+                    },
+                    {
+                        value: "custom",
+                        title: "Custom",
+                    },
+                ],
+                quickAdd: true,
+                defaultValue: {
+                    option: "all_time",
+                    startDate: null,
+                    endDate: null,
+                },
+            }*/
             {
                 label: "Plan",
                 identifier: "plan",


### PR DESCRIPTION
The date_range field type is a combination of `Select` and `KeyboardDatePicker` components.
The user can either choose from a predefined list of date ranges or choose a custom date
range. Currently it performs no validations to prevent invalid date ranges where the end
date occurs before the start end.