### PR TITLE
Added the select field type to RecordForm

### DIFF
--- a/src/workspace/RecordForm.js
+++ b/src/workspace/RecordForm.js
@@ -42,20 +42,17 @@ const useStyles = makeStyles((theme) => ({
 export function extractValues(groups) {
     const result = {};
     groups.forEach((group) => {
-        group.children.forEach(
-            (field) => {
-                if (field.type === "date_range") {
-                    result[field.identifier] = {
-                        option: field.defaultValue.option,
-                        startDate: field.defaultValue.startDate,
-                        endDate: field.defaultValue.endDate,
-                    };
-                }
-                else {
-                    result[field.identifier] = field.defaultValue;
-                }
+        group.children.forEach((field) => {
+            if (field.type === "date_range") {
+                result[field.identifier] = {
+                    option: field.defaultValue.option,
+                    startDate: field.defaultValue.startDate,
+                    endDate: field.defaultValue.endDate,
+                };
+            } else {
+                result[field.identifier] = field.defaultValue;
             }
-        );
+        });
     });
     return result;
 }
@@ -81,9 +78,25 @@ export default function RecordForm(props) {
         onValueChange(field, newValue);
     };
 
+    const renderSelect = (field) => (
+        <FormControl variant="outlined" fullWidth={true} size="medium">
+            <InputLabel id={field.identifier}>{field.label}</InputLabel>
+            <Select
+                labelId={field.identifier}
+                value={values[field.identifier]}
+                onChange={makeChangeHandler(field)}
+                label={field.label}
+            >
+                {field.options.map((option) => (
+                    <MenuItem value={option.value}>{option.title}</MenuItem>
+                ))}
+            </Select>
+        </FormControl>
+    );
+
     return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Grid container={true} spacing={2} className={classes.root}>
+            <Grid container={true} spacing={3} className={classes.root}>
                 {groups.map((group, groupIndex) =>
                     group.children.map((field, fieldIndex) =>
                         (!showMore && field.quickAdd) ||
@@ -103,7 +116,7 @@ export default function RecordForm(props) {
                                         required={field.required}
                                         value={values[field.identifier]}
                                         onChange={makeChangeHandler(field)}
-                                        size="small"
+                                        size="medium"
                                     />
                                 )}
 
@@ -120,7 +133,7 @@ export default function RecordForm(props) {
                                         required={field.required}
                                         value={values[field.identifier]}
                                         onChange={makeChangeHandler(field)}
-                                        size="small"
+                                        size="medium"
                                     />
                                 )}
 
@@ -135,7 +148,7 @@ export default function RecordForm(props) {
                                         required={field.required}
                                         value={values[field.identifier]}
                                         onChange={makeChangeHandler(field)}
-                                        size="small"
+                                        size="medium"
                                     />
                                 )}
 
@@ -160,7 +173,7 @@ export default function RecordForm(props) {
                                             field,
                                             "startDate"
                                         )}
-                                        size="small"
+                                        size="medium"
                                     />
                                 )}
 
@@ -175,14 +188,15 @@ export default function RecordForm(props) {
                                             value={values[field.identifier]}
                                             onChange={makeChangeHandler(field)}
                                         />
-                                    </FormGroup>)}
+                                    </FormGroup>
+                                )}
 
                                 {field.type === "date_range" && (
                                     <div>
                                         <FormControl
                                             variant="outlined"
                                             fullWidth={true}
-                                            size="small"
+                                            size="medium"
                                         >
                                             <InputLabel id={field.identifier}>
                                                 {field.title}
@@ -220,9 +234,11 @@ export default function RecordForm(props) {
                                                     format="MM/dd/yyyy"
                                                     inputVariant="outlined"
                                                     fullWidth={true}
-                                                    size="small"
+                                                    size="medium"
                                                     value={
-                                                        !values[field.identifier].startDate
+                                                        !values[
+                                                            field.identifier
+                                                        ].startDate
                                                             ? new Date()
                                                             : new Date(
                                                                   values[
@@ -244,9 +260,11 @@ export default function RecordForm(props) {
                                                     format="MM/dd/yyyy"
                                                     inputVariant="outlined"
                                                     fullWidth={true}
-                                                    size="small"
+                                                    size="medium"
                                                     value={
-                                                        !values[field.identifier].endDate
+                                                        !values[
+                                                            field.identifier
+                                                        ].endDate
                                                             ? new Date()
                                                             : new Date(
                                                                   values[
@@ -263,6 +281,8 @@ export default function RecordForm(props) {
                                         )}
                                     </div>
                                 )}
+
+                                {field.type === "select" && renderSelect(field)}
                             </Grid>
                         ) : null
                     )

--- a/src/workspace/plan/PlanFormDrawer.js
+++ b/src/workspace/plan/PlanFormDrawer.js
@@ -66,6 +66,16 @@ const groups = [
                 label: "Billing Period Unit",
                 identifier: "billingPeriodUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: true,
                 readOnly: false,
                 quickAdd: true,
@@ -73,7 +83,7 @@ const groups = [
                 hidden: false,
                 tooltip: "The billing period unit of the plan.",
                 multipleValues: false,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Price Per Period",
@@ -118,6 +128,16 @@ const groups = [
                 label: "Trial Period Unit",
                 identifier: "trialPeriodUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: true,
                 readOnly: false,
                 quickAdd: true,
@@ -125,7 +145,7 @@ const groups = [
                 hidden: false,
                 tooltip: "The trial period unit of the plan.",
                 multipleValues: false,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Term",
@@ -144,6 +164,16 @@ const groups = [
                 label: "Term Unit",
                 identifier: "termUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: true,
                 readOnly: false,
                 quickAdd: true,
@@ -151,7 +181,7 @@ const groups = [
                 hidden: false,
                 tooltip: "The term unit of the plan.",
                 multipleValues: false,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Renew",

--- a/src/workspace/subscription/SubscriptionFormDrawer.js
+++ b/src/workspace/subscription/SubscriptionFormDrawer.js
@@ -86,6 +86,16 @@ const groups = [
                 label: "Billing Period Unit",
                 identifier: "billingPeriodUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: false,
                 readOnly: false,
                 quickAdd: true,
@@ -93,7 +103,7 @@ const groups = [
                 hidden: false,
                 tooltip: "The number of billing period units.",
                 multipleValues: true,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Setup Fee",
@@ -125,6 +135,16 @@ const groups = [
                 label: "Trial Period Unit",
                 identifier: "trialPeriodUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: false,
                 readOnly: false,
                 quickAdd: true,
@@ -132,7 +152,7 @@ const groups = [
                 hidden: false,
                 tooltip: "Number of units of trial period.",
                 multipleValues: false,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Starts",
@@ -164,6 +184,16 @@ const groups = [
                 label: "Term Unit",
                 identifier: "termUnit",
                 type: "select",
+                options: [
+                    {
+                        value: "days",
+                        title: "Days",
+                    },
+                    {
+                        value: "months",
+                        title: "Months",
+                    },
+                ],
                 required: false,
                 readOnly: false,
                 quickAdd: true,
@@ -171,7 +201,7 @@ const groups = [
                 hidden: false,
                 tooltip: "Unit of the term.",
                 multipleValues: false,
-                defaultValue: "",
+                defaultValue: "days",
             },
             {
                 label: "Renew",


### PR DESCRIPTION
Updated all the form configurations that use the select field type to provide the options array.

The text field size in `RecordForm` was updated to medium from small for the time being. Further,
the grid spacing was updated to 3 from 2.